### PR TITLE
Support files with no "EVENT" in their parameters

### DIFF
--- a/gaitalytics/io.py
+++ b/gaitalytics/io.py
@@ -219,9 +219,10 @@ class C3dEventInputFileReader(_EventInputFileReader):
             A list containing the sections of the specified type.
         """
         sections = []
-        for section in self._c3d["parameters"]["EVENT"].keys():
-            if section.startswith(section_base):
-                sections.append(section)
+        if "parameters" in self._c3d and "EVENT" in self._c3d["parameters"]:
+            for section in self._c3d["parameters"]["EVENT"].keys():
+                if section.startswith(section_base):
+                    sections.append(section)
         return sections
 
     def _concat_sections(self, section_base: str) -> list:


### PR DESCRIPTION
Prevent crashes when reading the unexisting "EVENT" parameter, when reading files with no event.